### PR TITLE
Sensible implementations of Default

### DIFF
--- a/src/count.rs
+++ b/src/count.rs
@@ -21,16 +21,21 @@ use serde::{Deserialize, Serialize};
 /// }
 /// assert_eq!(running_count.get(), 0.);
 ///```
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Count<F: Float + FromPrimitive + AddAssign + SubAssign> {
     pub count: F,
 }
 
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> Count<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for Count<F> {
+    fn default() -> Self {
         Self {
             count: F::from_f64(0.0).unwrap(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Count<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/maximum.rs
+++ b/src/maximum.rs
@@ -15,15 +15,20 @@ use std::ops::{AddAssign, SubAssign};
 /// assert_eq!(running_max.get(), 9.0);
 /// ```
 ///
-#[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Max<F: Float + FromPrimitive + AddAssign + SubAssign> {
     pub max: F,
 }
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> Max<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for Max<F> {
+    fn default() -> Self {
         Self {
             max: F::min_value(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Max<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 
@@ -50,16 +55,21 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign> Univariate<F> for Max<F> 
 /// assert_eq!(running_abs_max.get(), 17.0);
 /// ```
 ///
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct AbsMax<F: Float + FromPrimitive + AddAssign + SubAssign> {
     abs_max: F,
 }
 
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> AbsMax<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for AbsMax<F> {
+    fn default() -> Self {
         Self {
             abs_max: F::from_f64(0.0).unwrap(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> AbsMax<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/mean.rs
+++ b/src/mean.rs
@@ -28,17 +28,22 @@ use serde::{Deserialize, Serialize};
 /// [^2]: [Finch, T., 2009. Incremental calculation of weighted mean and variance. University of Cambridge, 4(11-5), pp.41-42.](https://fanf2.user.srcf.net/hermes/doc/antiforgery/stats.pdf)
 ///
 /// [^3]: [Chan, T.F., Golub, G.H. and LeVeque, R.J., 1983. Algorithms for computing the sample variance: Analysis and recommendations. The American Statistician, 37(3), pp.242-247.](https://amstat.tandfonline.com/doi/abs/10.1080/00031305.1983.10483115)
-#[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Mean<F: Float + FromPrimitive + AddAssign + SubAssign> {
     pub mean: F,
     pub n: Count<F>,
 }
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> Mean<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for Mean<F> {
+    fn default() -> Self {
         Self {
             mean: F::from_f64(0.0).unwrap(),
             n: Count::new(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Mean<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/minimum.rs
+++ b/src/minimum.rs
@@ -74,3 +74,14 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign> Univariate<F> for Rolling
         self.sorted_window.front()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn min_default() {
+        let mut min: Min<f64> = Min::default();
+        min.update(1.0);
+        assert_eq!(min.get(), 1.0);
+    }
+}

--- a/src/minimum.rs
+++ b/src/minimum.rs
@@ -15,16 +15,21 @@ use std::ops::{AddAssign, SubAssign};
 /// assert_eq!(running_min.get(), 1.0);
 /// ```
 ///
-#[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Min<F: Float + FromPrimitive + AddAssign + SubAssign> {
     pub min: F,
 }
 
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> Min<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for Min<F> {
+    fn default() -> Self {
         Self {
             min: F::max_value(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Min<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/moments.rs
+++ b/src/moments.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Computes central moments using Welford's algorithm.
 /// # References
 /// [^1]: [Wikipedia article on algorithms for calculating variance](https://www.wikiwand.com/en/Algorithms_for_calculating_variance#/Covariance)
-#[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct CentralMoments<F: Float + FromPrimitive + AddAssign + SubAssign> {
     pub delta: F,
     pub sum_delta: F,
@@ -22,8 +22,8 @@ pub struct CentralMoments<F: Float + FromPrimitive + AddAssign + SubAssign> {
     /// Sums of powers of differences from the mean order 4.
     pub count: Count<F>,
 }
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> CentralMoments<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for CentralMoments<F> {
+    fn default() -> Self {
         Self {
             delta: F::from_f64(0.).unwrap(),
             sum_delta: F::from_f64(0.).unwrap(),
@@ -33,6 +33,11 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign> CentralMoments<F> {
             m4: F::from_f64(0.).unwrap(),
             count: Count::new(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> CentralMoments<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
     pub fn update_delta(&mut self, x: F) {
         self.delta = (x - self.sum_delta) / self.count.get()

--- a/src/ptp.rs
+++ b/src/ptp.rs
@@ -16,18 +16,23 @@ use std::ops::{AddAssign, SubAssign};
 /// assert_eq!(running_peak_to_peak.get(), 8.0);
 /// ```
 ///
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct PeakToPeak<F: Float + FromPrimitive + AddAssign + SubAssign> {
     pub min: Min<F>,
     pub max: Max<F>,
 }
 
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> PeakToPeak<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for PeakToPeak<F> {
+    fn default() -> Self {
         Self {
             min: Min::new(),
             max: Max::new(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> PeakToPeak<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/sum.rs
+++ b/src/sum.rs
@@ -21,16 +21,21 @@ use std::ops::{AddAssign, SubAssign};
 /// assert_eq!(running_sum.get(), 0.);
 /// ```
 ///
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Sum<F: Float + FromPrimitive + AddAssign + SubAssign> {
     pub sum: F,
 }
 
-impl<F: Float + FromPrimitive + AddAssign + SubAssign> Sum<F> {
-    pub fn new() -> Self {
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Default for Sum<F> {
+    fn default() -> Self {
         Self {
             sum: F::from_f64(0.0).unwrap(),
         }
+    }
+}
+impl<F: Float + FromPrimitive + AddAssign + SubAssign> Sum<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 impl<F: Float + FromPrimitive + AddAssign + SubAssign> Univariate<F> for Sum<F> {


### PR DESCRIPTION
Some `Default` implementations are derived and do not behave as expected.

E.g. the following code fails:
```rust
let mut min: Min<f64> = Min::default();
min.update(1.0);
assert_eq!(min.get(), 1.0);
```

This PR fixes `Default` implementations by:
- moving existing `new()` implementations to `Default::default()`
- delegating `new()` to `Self::default()` for backward compatibility

Types changed by this PR (note: not all were actually broken):
- `Count`
- `Max` and `AbsMax`
- `Mean`
- `Min`
- `CentralMoments`
- `PeakToPeak`
- `Sum`